### PR TITLE
Add OpenAI models doc

### DIFF
--- a/AI_DOCS/openai_models.md
+++ b/AI_DOCS/openai_models.md
@@ -1,0 +1,83 @@
+# Latest OpenAI Models (as of July 2025)
+
+The following list was generated from the [OpenAI OpenAPI specification](https://github.com/openai/openai-openapi/tree/manual_spec) updated on 2025‑04‑29. It groups available models by capability.
+
+## Chat and Completion Models
+- babbage-002
+- davinci-002
+- gpt-3.5-turbo
+- gpt-3.5-turbo-0125
+- gpt-3.5-turbo-0301
+- gpt-3.5-turbo-0613
+- gpt-3.5-turbo-1106
+- gpt-3.5-turbo-16k
+- gpt-3.5-turbo-16k-0613
+- gpt-3.5-turbo-instruct
+- gpt-4
+- gpt-4-0125-preview
+- gpt-4-0314
+- gpt-4-0613
+- gpt-4-1106-preview
+- gpt-4-32k
+- gpt-4-32k-0314
+- gpt-4-32k-0613
+- gpt-4-turbo
+- gpt-4-turbo-2024-04-09
+- gpt-4-turbo-and-gpt-4
+- gpt-4-turbo-preview
+- gpt-4-vision-preview
+- gpt-4.1
+- gpt-4.1-2025-04-14
+- gpt-4.1-mini
+- gpt-4.1-mini-2025-04-14
+- gpt-4.1-nano
+- gpt-4.1-nano-2025-04-14
+- gpt-4.5-preview
+- gpt-4.5-preview-2025-02-27
+- gpt-4o
+- gpt-4o-2024-05-13
+- gpt-4o-2024-08-06
+- gpt-4o-2024-11-20
+- gpt-4o-latest
+- gpt-4o-mini
+- gpt-4o-mini-2024-07-18
+- gpt-4o-mini-realtime-preview
+- gpt-4o-mini-realtime-preview-2024-12-17
+- gpt-4o-mini-search-preview
+- gpt-4o-mini-search-preview-2025-03-11
+- gpt-4o-mini-audio-preview
+- gpt-4o-mini-audio-preview-2024-12-17
+- gpt-4o-mini-transcribe
+- gpt-4o-mini-tts
+- gpt-4o-realtime-preview
+- gpt-4o-realtime-preview-2024-10-01
+- gpt-4o-realtime-preview-2024-12-17
+- gpt-4o-search-preview
+- gpt-4o-search-preview-2025-03-11
+- gpt-4o-audio-preview
+- gpt-4o-audio-preview-2024-10-01
+- gpt-4o-audio-preview-2024-12-17
+- gpt-4o-transcribe
+- gpt-4.1
+
+## Image Models
+- dall-e-2
+- dall-e-3
+- gpt-image-1
+
+## Audio and Speech Models
+- whisper-1
+- tts-1
+- tts-1-hd
+- gpt-4o-transcribe
+- gpt-4o-mini-transcribe
+- gpt-4o-mini-tts
+
+## Embedding Models
+- text-embedding-3
+- text-embedding-3-large
+- text-embedding-3-small
+- text-embedding-ada-002
+- text-embedding-ada-002-v2
+
+These model IDs can be passed to the OpenAI API `model` parameter for the appropriate endpoint (chat completions, speech, images, or embeddings).

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 
 ## Assistant Tools
 > See [TOOLS.md](TOOLS.md) for a detailed list of available tools and their descriptions.
+> See [AI_DOCS/openai_models.md](AI_DOCS/openai_models.md) for a list of currently available OpenAI models.
 
 ## Personalization
 


### PR DESCRIPTION
## Summary
- add openai_models.md listing models parsed from OpenAPI spec
- reference new doc from README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets', ModuleNotFoundError: No module named 'pyaudio')*

------
https://chatgpt.com/codex/tasks/task_e_68643c9349e4832a80185f10f90987de